### PR TITLE
[Remove] Removed the verify_class_id function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -738,10 +738,6 @@ pub mod pallet {
             Ok(balances)
         }
 
-        pub fn verify_class_id_(class_id: T::ClassId) -> bool {
-            return Classes::<T>::contains_key(class_id);
-        }
-
         fn add_balance_to(
             to: &T::AccountId,
             class_id: T::ClassId,


### PR DESCRIPTION
because there was a function to obtain the same response > class_exists